### PR TITLE
Fix docs on using tau as a shebang and behaviour of the VM (exec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ println("Hello World")
 As every interpreter Tau supports files either by passing the path to the interpreter or by using the shebang.
 
 ```python
-# helloworld.tau
+#!/path/to/tau
 
 println("hello world")
 ```

--- a/main.go
+++ b/main.go
@@ -112,8 +112,6 @@ func execFileVM(f string) {
 		fmt.Printf("runtime error: %v\n", err)
 		return
 	}
-
-	fmt.Println(tvm.LastPoppedStackElem())
 }
 
 func execFileEval(f string) {
@@ -128,10 +126,7 @@ func execFileEval(f string) {
 		return
 	}
 
-	val := res.Eval(env)
-	if val != obj.NullObj && val != nil {
-		fmt.Println(val)
-	}
+	res.Eval(env)
 }
 
 func compileFiles(files []string) {


### PR DESCRIPTION
IMO the VM should not print the last value on the stack. This is inconsistent with the [README](/README.md) and generally if you're using `tau /path/to/program.tau` or via the shebang, you really don't care about that last value anyway -- only in a REPL I guess? 🤔