### PR TITLE
stdlib: strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /tau
 /cmd/tau/tau
 !/examples/*.tau
+!/stdlib/*.tau

--- a/cmd/tau/main.go
+++ b/cmd/tau/main.go
@@ -12,10 +12,12 @@ func main() {
 		compile bool
 		useEval bool
 		version bool
+		simple  bool
 	)
 
 	flag.BoolVar(&useEval, "eval", false, "Use the Tau eval function instead of the Tau VM. (slower)")
 	flag.BoolVar(&compile, "c", false, "Compile a tau file into a '.tauc' bytecode file.")
+	flag.BoolVar(&simple, "s", false, "Use simple REPL instead of opening a terminal.")
 	flag.BoolVar(&version, "v", false, "Print Tau version information.")
 	flag.Parse()
 
@@ -31,6 +33,13 @@ func main() {
 			tau.ExecFileEval(flag.Arg(0))
 		} else {
 			tau.ExecFileVM(flag.Arg(0))
+		}
+
+	case simple:
+		if useEval {
+			tau.SimpleEvalREPL()
+		} else {
+			tau.SimpleVmREPL()
 		}
 
 	default:

--- a/internal/ast/and.go
+++ b/internal/ast/and.go
@@ -30,7 +30,7 @@ func (a And) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	return obj.ParseBool(isTruthy(left) && isTruthy(right))
+	return obj.ParseBool(obj.IsTruthy(left) && obj.IsTruthy(right))
 }
 
 func (a And) String() string {

--- a/internal/ast/bitwiseand.go
+++ b/internal/ast/bitwiseand.go
@@ -30,16 +30,16 @@ func (b BitwiseAnd) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '&' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '&' for type %v", right.Type())
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return obj.NewInteger(l & r)
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return obj.Integer(l & r)
 }
 
 func (b BitwiseAnd) String() string {

--- a/internal/ast/bitwiseandassign.go
+++ b/internal/ast/bitwiseandassign.go
@@ -34,22 +34,22 @@ func (b BitwiseAndAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '&=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '&=' for type %v", right.Type())
 	}
 
 	if gs, ok := left.(obj.GetSetter); ok {
-		l := gs.Object().(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return gs.Set(obj.NewInteger(l & r))
+		l := gs.Object().(obj.Integer)
+		r := right.(obj.Integer)
+		return gs.Set(obj.Integer(l & r))
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return env.Set(name, obj.NewInteger(l&r))
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return env.Set(name, obj.Integer(l&r))
 }
 
 func (b BitwiseAndAssign) String() string {

--- a/internal/ast/bitwisenot.go
+++ b/internal/ast/bitwisenot.go
@@ -23,12 +23,12 @@ func (b BitwiseNot) Eval(env *obj.Env) obj.Object {
 		return value
 	}
 
-	if !assertTypes(value, obj.IntType) {
+	if !obj.AssertTypes(value, obj.IntType) {
 		return obj.NewError("unsupported operator '~' for type %v", value.Type())
 	}
 
-	n := value.(obj.Integer).Val()
-	return obj.NewInteger(^n)
+	n := value.(obj.Integer)
+	return obj.Integer(^n)
 }
 
 func (b BitwiseNot) String() string {

--- a/internal/ast/bitwiseor.go
+++ b/internal/ast/bitwiseor.go
@@ -30,16 +30,16 @@ func (b BitwiseOr) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '|' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '|' for type %v", right.Type())
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return obj.NewInteger(l | r)
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return obj.Integer(l | r)
 }
 
 func (b BitwiseOr) String() string {

--- a/internal/ast/bitwiseorassign.go
+++ b/internal/ast/bitwiseorassign.go
@@ -33,22 +33,22 @@ func (b BitwiseOrAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '|=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '|=' for type %v", right.Type())
 	}
 
 	if gs, ok := left.(obj.GetSetter); ok {
-		l := gs.Object().(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return gs.Set(obj.NewInteger(l | r))
+		l := gs.Object().(obj.Integer)
+		r := right.(obj.Integer)
+		return gs.Set(obj.Integer(l | r))
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return env.Set(name, obj.NewInteger(l|r))
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return env.Set(name, obj.Integer(l|r))
 }
 
 func (b BitwiseOrAssign) String() string {

--- a/internal/ast/bitwiseshiftleft.go
+++ b/internal/ast/bitwiseshiftleft.go
@@ -30,16 +30,16 @@ func (b BitwiseLeftShift) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '<<' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '<<' for type %v", right.Type())
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return obj.NewInteger(l << r)
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return obj.Integer(l << r)
 }
 
 func (b BitwiseLeftShift) String() string {

--- a/internal/ast/bitwiseshiftleftassign.go
+++ b/internal/ast/bitwiseshiftleftassign.go
@@ -34,22 +34,22 @@ func (b BitwiseShiftLeftAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '<<=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '<<=' for type %v", right.Type())
 	}
 
 	if gs, ok := left.(obj.GetSetter); ok {
-		l := gs.Object().(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return gs.Set(obj.NewInteger(l << r))
+		l := gs.Object().(obj.Integer)
+		r := right.(obj.Integer)
+		return gs.Set(obj.Integer(l << r))
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return env.Set(name, obj.NewInteger(l<<r))
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return env.Set(name, obj.Integer(l<<r))
 }
 
 func (b BitwiseShiftLeftAssign) String() string {

--- a/internal/ast/bitwiseshiftright.go
+++ b/internal/ast/bitwiseshiftright.go
@@ -30,16 +30,16 @@ func (b BitwiseRightShift) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '>>' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '>>' for type %v", right.Type())
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return obj.NewInteger(l >> r)
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return obj.Integer(l >> r)
 }
 
 func (b BitwiseRightShift) String() string {

--- a/internal/ast/bitwiseshiftrightassign.go
+++ b/internal/ast/bitwiseshiftrightassign.go
@@ -34,22 +34,22 @@ func (b BitwiseShiftRightAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '>>=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '>>=' for type %v", right.Type())
 	}
 
 	if gs, ok := left.(obj.GetSetter); ok {
-		l := gs.Object().(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return gs.Set(obj.NewInteger(l >> r))
+		l := gs.Object().(obj.Integer)
+		r := right.(obj.Integer)
+		return gs.Set(obj.Integer(l >> r))
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return env.Set(name, obj.NewInteger(l>>r))
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return env.Set(name, obj.Integer(l>>r))
 }
 
 func (b BitwiseShiftRightAssign) String() string {

--- a/internal/ast/bitwisexor.go
+++ b/internal/ast/bitwisexor.go
@@ -30,16 +30,16 @@ func (b BitwiseXor) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '^' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '^' for type %v", right.Type())
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return obj.NewInteger(l ^ r)
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return obj.Integer(l ^ r)
 }
 
 func (b BitwiseXor) String() string {

--- a/internal/ast/bitwisexorassign.go
+++ b/internal/ast/bitwisexorassign.go
@@ -34,22 +34,22 @@ func (b BitwiseXorAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '^=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '^=' for type %v", right.Type())
 	}
 
 	if gs, ok := left.(obj.GetSetter); ok {
-		l := gs.Object().(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return gs.Set(obj.NewInteger(l ^ r))
+		l := gs.Object().(obj.Integer)
+		r := right.(obj.Integer)
+		return gs.Set(obj.Integer(l ^ r))
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
-	return env.Set(name, obj.NewInteger(l^r))
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
+	return env.Set(name, obj.Integer(l^r))
 }
 
 func (b BitwiseXorAssign) String() string {

--- a/internal/ast/divide.go
+++ b/internal/ast/divide.go
@@ -30,17 +30,17 @@ func (d Divide) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '/' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '/' for type %v", right.Type())
 	}
 
-	left, right = toFloat(left, right)
-	l := left.(obj.Float).Val()
-	r := right.(obj.Float).Val()
-	return obj.NewFloat(l / r)
+	left, right = obj.ToFloat(left, right)
+	l := left.(obj.Float)
+	r := right.(obj.Float)
+	return obj.Float(l / r)
 }
 
 func (d Divide) String() string {

--- a/internal/ast/divideassign.go
+++ b/internal/ast/divideassign.go
@@ -34,24 +34,24 @@ func (d DivideAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '/=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '/=' for type %v", right.Type())
 	}
 
 	if gs, ok := left.(obj.GetSetter); ok {
-		leftFl, rightFl := toFloat(gs.Object(), right)
-		l := leftFl.(obj.Float).Val()
-		r := rightFl.(obj.Float).Val()
-		return gs.Set(obj.NewFloat(l / r))
+		leftFl, rightFl := obj.ToFloat(gs.Object(), right)
+		l := leftFl.(obj.Float)
+		r := rightFl.(obj.Float)
+		return gs.Set(obj.Float(l / r))
 	}
 
-	leftFl, rightFl := toFloat(left, right)
-	l := leftFl.(obj.Float).Val()
-	r := rightFl.(obj.Float).Val()
-	return env.Set(name, obj.NewFloat(l/r))
+	leftFl, rightFl := obj.ToFloat(left, right)
+	l := leftFl.(obj.Float)
+	r := rightFl.(obj.Float)
+	return env.Set(name, obj.Float(l/r))
 }
 
 func (d DivideAssign) String() string {

--- a/internal/ast/dot.go
+++ b/internal/ast/dot.go
@@ -62,7 +62,7 @@ func (d Dot) Compile(c *compiler.Compiler) (position int, err error) {
 	if _, ok := d.r.(Identifier); !ok {
 		return position, fmt.Errorf("expected identifier with dot operator, got %T", d.r)
 	}
-	position = c.Emit(code.OpConstant, c.AddConstant(obj.NewString(d.r.String())))
+	position = c.Emit(code.OpConstant, c.AddConstant(obj.String(d.r.String())))
 	return c.Emit(code.OpDot), nil
 }
 

--- a/internal/ast/equals.go
+++ b/internal/ast/equals.go
@@ -30,31 +30,31 @@ func (e Equals) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
 		return obj.NewError("unsupported operator '==' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
 		return obj.NewError("unsupported operator '==' for type %v", right.Type())
 	}
 
 	switch {
-	case assertTypes(left, obj.BoolType, obj.NullType) || assertTypes(right, obj.BoolType, obj.NullType):
+	case obj.AssertTypes(left, obj.BoolType, obj.NullType) || obj.AssertTypes(right, obj.BoolType, obj.NullType):
 		return obj.ParseBool(left == right)
 
-	case assertTypes(left, obj.StringType) && assertTypes(right, obj.StringType):
-		l := left.(obj.String).Val()
-		r := right.(obj.String).Val()
+	case obj.AssertTypes(left, obj.StringType) && obj.AssertTypes(right, obj.StringType):
+		l := left.(obj.String)
+		r := right.(obj.String)
 		return obj.ParseBool(l == r)
 
-	case assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType):
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
 		return obj.ParseBool(l == r)
 
-	case assertTypes(left, obj.FloatType, obj.IntType) && assertTypes(right, obj.FloatType, obj.IntType):
-		left, right = toFloat(left, right)
-		l := left.(obj.Float).Val()
-		r := right.(obj.Float).Val()
+	case obj.AssertTypes(left, obj.FloatType, obj.IntType) && obj.AssertTypes(right, obj.FloatType, obj.IntType):
+		left, right = obj.ToFloat(left, right)
+		l := left.(obj.Float)
+		r := right.(obj.Float)
 		return obj.ParseBool(l == r)
 
 	default:

--- a/internal/ast/float.go
+++ b/internal/ast/float.go
@@ -15,7 +15,7 @@ func NewFloat(f float64) Node {
 }
 
 func (f Float) Eval(env *obj.Env) obj.Object {
-	return obj.NewFloat(float64(f))
+	return obj.Float(float64(f))
 }
 
 func (f Float) String() string {
@@ -23,7 +23,7 @@ func (f Float) String() string {
 }
 
 func (f Float) Compile(c *compiler.Compiler) (position int, err error) {
-	return c.Emit(code.OpConstant, c.AddConstant(obj.NewFloat(float64(f)))), nil
+	return c.Emit(code.OpConstant, c.AddConstant(obj.Float(float64(f)))), nil
 }
 
 func (f Float) IsConstExpression() bool {

--- a/internal/ast/for.go
+++ b/internal/ast/for.go
@@ -25,7 +25,7 @@ func (f For) Eval(env *obj.Env) obj.Object {
 	}
 
 loop:
-	for isTruthy(obj.Unwrap(f.cond.Eval(env))) {
+	for obj.IsTruthy(obj.Unwrap(f.cond.Eval(env))) {
 		switch o := obj.Unwrap(f.body.Eval(env)); {
 		case o == nil:
 			break

--- a/internal/ast/function.go
+++ b/internal/ast/function.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Function struct {
-	params []Identifier
 	body   Node
 	Name   string
+	params []Identifier
 }
 
 func NewFunction(params []Identifier, body Node) Node {

--- a/internal/ast/greater.go
+++ b/internal/ast/greater.go
@@ -30,23 +30,26 @@ func (g Greater) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
-		return obj.NewError("unsupported operator '>' for type %v", left.Type())
-	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
-		return obj.NewError("unsupported operator '>' for type %v", right.Type())
-	}
-
-	if assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType) {
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
+	switch {
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
 		return obj.ParseBool(l > r)
-	}
 
-	left, right = toFloat(left, right)
-	l := left.(obj.Float).Val()
-	r := right.(obj.Float).Val()
-	return obj.ParseBool(l > r)
+	case obj.AssertTypes(left, obj.IntType, obj.FloatType) && obj.AssertTypes(right, obj.IntType, obj.FloatType):
+		left, right = obj.ToFloat(left, right)
+		l := left.(obj.Float)
+		r := right.(obj.Float)
+		return obj.ParseBool(l > r)
+
+	case obj.AssertTypes(left, obj.StringType) && obj.AssertTypes(right, obj.StringType):
+		l := left.(obj.String)
+		r := right.(obj.String)
+		return obj.ParseBool(l > r)
+
+	default:
+		return obj.NewError("unsupported operator '>' for types %v and %v", left.Type(), right.Type())
+	}
 }
 
 func (g Greater) String() string {

--- a/internal/ast/greatereq.go
+++ b/internal/ast/greatereq.go
@@ -30,23 +30,26 @@ func (g GreaterEq) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
-		return obj.NewError("unsupported operator '>=' for type %v", left.Type())
-	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
-		return obj.NewError("unsupported operator '>=' for type %v", right.Type())
-	}
-
-	if assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType) {
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
+	switch {
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
 		return obj.ParseBool(l >= r)
-	}
 
-	left, right = toFloat(left, right)
-	l := left.(obj.Float).Val()
-	r := right.(obj.Float).Val()
-	return obj.ParseBool(l >= r)
+	case obj.AssertTypes(left, obj.IntType, obj.FloatType) && obj.AssertTypes(right, obj.IntType, obj.FloatType):
+		left, right = obj.ToFloat(left, right)
+		l := left.(obj.Float)
+		r := right.(obj.Float)
+		return obj.ParseBool(l >= r)
+
+	case obj.AssertTypes(left, obj.StringType) && obj.AssertTypes(right, obj.StringType):
+		l := left.(obj.String)
+		r := right.(obj.String)
+		return obj.ParseBool(l >= r)
+
+	default:
+		return obj.NewError("unsupported operator '>=' for types %v and %v", left.Type(), right.Type())
+	}
 }
 
 func (g GreaterEq) String() string {

--- a/internal/ast/in.go
+++ b/internal/ast/in.go
@@ -31,25 +31,25 @@ func (i In) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
 		return obj.NewError("unsupported operator 'in' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.ListType, obj.StringType) {
+	if !obj.AssertTypes(right, obj.ListType, obj.StringType) {
 		return obj.NewError("unsupported operator 'in' for type %v", right.Type())
 	}
 
 	switch {
-	case assertTypes(left, obj.StringType) && assertTypes(right, obj.StringType):
+	case obj.AssertTypes(left, obj.StringType) && obj.AssertTypes(right, obj.StringType):
 		l := left.(obj.String).Val()
 		r := right.(obj.String).Val()
 		return obj.ParseBool(strings.Contains(r, l))
 
-	case assertTypes(right, obj.ListType):
+	case obj.AssertTypes(right, obj.ListType):
 		for _, o := range right.(obj.List).Val() {
-			if !assertTypes(left, o.Type()) {
+			if !obj.AssertTypes(left, o.Type()) {
 				continue
 			}
-			if assertTypes(left, obj.BoolType, obj.NullType) && left == o {
+			if obj.AssertTypes(left, obj.BoolType, obj.NullType) && left == o {
 				return obj.True
 			}
 

--- a/internal/ast/index.go
+++ b/internal/ast/index.go
@@ -31,9 +31,9 @@ func (i Index) Eval(env *obj.Env) obj.Object {
 	}
 
 	switch {
-	case assertTypes(lft, obj.ListType) && assertTypes(idx, obj.IntType):
+	case obj.AssertTypes(lft, obj.ListType) && obj.AssertTypes(idx, obj.IntType):
 		l := lft.(obj.List)
-		i := idx.(obj.Integer).Val()
+		i := idx.(obj.Integer)
 
 		return &obj.GetSetterImpl{
 			GetFunc: func() (obj.Object, bool) {
@@ -53,25 +53,25 @@ func (i Index) Eval(env *obj.Env) obj.Object {
 			},
 		}
 
-	case assertTypes(lft, obj.StringType) && assertTypes(idx, obj.IntType):
+	case obj.AssertTypes(lft, obj.StringType) && obj.AssertTypes(idx, obj.IntType):
 		s := lft.(obj.String)
-		i := idx.(obj.Integer).Val()
+		i := idx.(obj.Integer)
 
 		if i < 0 || int(i) >= len(s) {
 			return obj.NewError("intex out of range")
 		}
-		return obj.NewString(string(string(s)[i]))
+		return obj.String(string(string(s)[i]))
 
-	case assertTypes(lft, obj.BytesType) && assertTypes(idx, obj.IntType):
+	case obj.AssertTypes(lft, obj.BytesType) && obj.AssertTypes(idx, obj.IntType):
 		b := lft.(obj.Bytes)
 		i := idx.(obj.Integer)
 
 		if i < 0 || int(i) >= len(b) {
 			return obj.NewError("intex out of range")
 		}
-		return obj.NewInteger(int64(b[i]))
+		return obj.Integer(int64(b[i]))
 
-	case assertTypes(lft, obj.MapType) && assertTypes(idx, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType):
+	case obj.AssertTypes(lft, obj.MapType) && obj.AssertTypes(idx, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType):
 		m := lft.(obj.Map)
 		k := idx.(obj.Hashable)
 		return &obj.GetSetterImpl{

--- a/internal/ast/integer.go
+++ b/internal/ast/integer.go
@@ -15,7 +15,7 @@ func NewInteger(i int64) Node {
 }
 
 func (i Integer) Eval(env *obj.Env) obj.Object {
-	return obj.NewInteger(int64(i))
+	return obj.Integer(int64(i))
 }
 
 func (i Integer) String() string {
@@ -23,7 +23,7 @@ func (i Integer) String() string {
 }
 
 func (i Integer) Compile(c *compiler.Compiler) (position int, err error) {
-	return c.Emit(code.OpConstant, c.AddConstant(obj.NewInteger(int64(i)))), nil
+	return c.Emit(code.OpConstant, c.AddConstant(obj.Integer(int64(i)))), nil
 }
 
 func (i Integer) IsConstExpression() bool {

--- a/internal/ast/less.go
+++ b/internal/ast/less.go
@@ -30,23 +30,26 @@ func (l Less) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
-		return obj.NewError("unsupported operator '<' for type %v", left.Type())
-	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
-		return obj.NewError("unsupported operator '<' for type %v", right.Type())
-	}
+	switch {
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
+		return obj.ParseBool(l < r)
 
-	if assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType) {
-		le := left.(obj.Integer).Val()
-		ri := right.(obj.Integer).Val()
-		return obj.ParseBool(le < ri)
-	}
+	case obj.AssertTypes(left, obj.IntType, obj.FloatType) && obj.AssertTypes(right, obj.IntType, obj.FloatType):
+		left, right = obj.ToFloat(left, right)
+		l := left.(obj.Float)
+		r := right.(obj.Float)
+		return obj.ParseBool(l < r)
 
-	left, right = toFloat(left, right)
-	le := left.(obj.Float).Val()
-	ri := right.(obj.Float).Val()
-	return obj.ParseBool(le < ri)
+	case obj.AssertTypes(left, obj.StringType) && obj.AssertTypes(right, obj.StringType):
+		l := left.(obj.String)
+		r := right.(obj.String)
+		return obj.ParseBool(l < r)
+
+	default:
+		return obj.NewError("unsupported operator '<' for types %v and %v", left.Type(), right.Type())
+	}
 }
 
 func (l Less) String() string {

--- a/internal/ast/lesseq.go
+++ b/internal/ast/lesseq.go
@@ -30,23 +30,26 @@ func (l LessEq) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
-		return obj.NewError("unsupported operator '<=' for type %v", left.Type())
-	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
-		return obj.NewError("unsupported operator '<=' for type %v", right.Type())
-	}
+	switch {
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
+		return obj.ParseBool(l <= r)
 
-	if assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType) {
-		le := left.(obj.Integer).Val()
-		ri := right.(obj.Integer).Val()
-		return obj.ParseBool(le <= ri)
-	}
+	case obj.AssertTypes(left, obj.IntType, obj.FloatType) && obj.AssertTypes(right, obj.IntType, obj.FloatType):
+		left, right = obj.ToFloat(left, right)
+		l := left.(obj.Float)
+		r := right.(obj.Float)
+		return obj.ParseBool(l <= r)
 
-	left, right = toFloat(left, right)
-	le := left.(obj.Float).Val()
-	ri := right.(obj.Float).Val()
-	return obj.ParseBool(le <= ri)
+	case obj.AssertTypes(left, obj.StringType) && obj.AssertTypes(right, obj.StringType):
+		l := left.(obj.String)
+		r := right.(obj.String)
+		return obj.ParseBool(l <= r)
+
+	default:
+		return obj.NewError("unsupported operator '<=' for types %v and %v", left.Type(), right.Type())
+	}
 }
 
 func (l LessEq) String() string {

--- a/internal/ast/minus.go
+++ b/internal/ast/minus.go
@@ -30,23 +30,23 @@ func (m Minus) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '-' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '-' for type %v", right.Type())
 	}
 
-	if assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType) {
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return obj.NewInteger(l - r)
+	if obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType) {
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
+		return obj.Integer(l - r)
 	}
 
-	left, right = toFloat(left, right)
-	l := left.(obj.Float).Val()
-	r := right.(obj.Float).Val()
-	return obj.NewFloat(l - r)
+	left, right = obj.ToFloat(left, right)
+	l := left.(obj.Float)
+	r := right.(obj.Float)
+	return obj.Float(l - r)
 }
 
 func (m Minus) String() string {

--- a/internal/ast/minusassign.go
+++ b/internal/ast/minusassign.go
@@ -34,37 +34,37 @@ func (m MinusAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '-=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '-=' for type %v", right.Type())
 	}
 
 	switch {
-	case assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType):
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
 		if gs, ok := left.(obj.GetSetter); ok {
-			l := gs.Object().(obj.Integer).Val()
-			r := right.(obj.Integer).Val()
-			return gs.Set(obj.NewInteger(l - r))
+			l := gs.Object().(obj.Integer)
+			r := right.(obj.Integer)
+			return gs.Set(obj.Integer(l - r))
 		}
 
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return env.Set(name, obj.NewInteger(l-r))
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
+		return env.Set(name, obj.Integer(l-r))
 
-	case assertTypes(left, obj.FloatType, obj.IntType) && assertTypes(right, obj.FloatType, obj.IntType):
+	case obj.AssertTypes(left, obj.FloatType, obj.IntType) && obj.AssertTypes(right, obj.FloatType, obj.IntType):
 		if gs, ok := left.(obj.GetSetter); ok {
-			leftFl, rightFl := toFloat(gs.Object(), right)
-			l := leftFl.(obj.Float).Val()
-			r := rightFl.(obj.Float).Val()
-			return gs.Set(obj.NewFloat(l - r))
+			leftFl, rightFl := obj.ToFloat(gs.Object(), right)
+			l := leftFl.(obj.Float)
+			r := rightFl.(obj.Float)
+			return gs.Set(obj.Float(l - r))
 		}
 
-		leftFl, rightFl := toFloat(left, right)
-		l := leftFl.(obj.Float).Val()
-		r := rightFl.(obj.Float).Val()
-		return env.Set(name, obj.NewFloat(l-r))
+		leftFl, rightFl := obj.ToFloat(left, right)
+		l := leftFl.(obj.Float)
+		r := rightFl.(obj.Float)
+		return env.Set(name, obj.Float(l-r))
 
 	default:
 		return obj.NewError(

--- a/internal/ast/minusminus.go
+++ b/internal/ast/minusminus.go
@@ -29,29 +29,29 @@ func (m MinusMinus) Eval(env *obj.Env) obj.Object {
 		name = ident.String()
 	}
 
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '--' for type %v", right.Type())
 	}
 
-	if assertTypes(right, obj.IntType) {
+	if obj.AssertTypes(right, obj.IntType) {
 		if gs, ok := right.(obj.GetSetter); ok {
-			r := gs.Object().(obj.Integer).Val()
-			return gs.Set(obj.NewInteger(r - 1))
+			r := gs.Object().(obj.Integer)
+			return gs.Set(obj.Integer(r - 1))
 		}
 
-		r := right.(obj.Integer).Val()
-		return env.Set(name, obj.NewInteger(r-1))
+		r := right.(obj.Integer)
+		return env.Set(name, obj.Integer(r-1))
 	}
 
 	if gs, ok := right.(obj.GetSetter); ok {
-		rightFl, _ := toFloat(gs.Object(), obj.NullObj)
-		r := rightFl.(obj.Float).Val()
-		return gs.Set(obj.NewFloat(r - 1))
+		rightFl, _ := obj.ToFloat(gs.Object(), obj.NullObj)
+		r := rightFl.(obj.Float)
+		return gs.Set(obj.Float(r - 1))
 	}
 
-	rightFl, _ := toFloat(right, obj.NullObj)
-	r := rightFl.(obj.Float).Val()
-	return env.Set(name, obj.NewFloat(r-1))
+	rightFl, _ := obj.ToFloat(right, obj.NullObj)
+	r := rightFl.(obj.Float)
+	return env.Set(name, obj.Float(r-1))
 }
 
 func (m MinusMinus) String() string {

--- a/internal/ast/mod.go
+++ b/internal/ast/mod.go
@@ -30,20 +30,20 @@ func (m Mod) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '%%' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '%%' for type %v", right.Type())
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
 
 	if r == 0 {
 		return obj.NewError("can't divide by 0")
 	}
-	return obj.NewInteger(l % r)
+	return obj.Integer(l % r)
 }
 
 func (m Mod) String() string {

--- a/internal/ast/modassign.go
+++ b/internal/ast/modassign.go
@@ -34,29 +34,29 @@ func (m ModAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType) {
+	if !obj.AssertTypes(left, obj.IntType) {
 		return obj.NewError("unsupported operator '%%=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType) {
+	if !obj.AssertTypes(right, obj.IntType) {
 		return obj.NewError("unsupported operator '%%=' for type %v", right.Type())
 	}
 
 	if gs, ok := left.(obj.GetSetter); ok {
-		l := gs.Object().(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
+		l := gs.Object().(obj.Integer)
+		r := right.(obj.Integer)
 		if r == 0 {
 			return obj.NewError("can't divide by 0")
 		}
-		return gs.Set(obj.NewInteger(l % r))
+		return gs.Set(obj.Integer(l % r))
 	}
 
-	l := left.(obj.Integer).Val()
-	r := right.(obj.Integer).Val()
+	l := left.(obj.Integer)
+	r := right.(obj.Integer)
 
 	if r == 0 {
 		return obj.NewError("can't divide by 0")
 	}
-	return env.Set(name, obj.NewInteger(l%r))
+	return env.Set(name, obj.Integer(l%r))
 }
 
 func (m ModAssign) String() string {

--- a/internal/ast/node.go
+++ b/internal/ast/node.go
@@ -39,37 +39,3 @@ func isContinue(o obj.Object) bool {
 func isBreak(o obj.Object) bool {
 	return o == obj.BreakObj
 }
-
-func isTruthy(o obj.Object) bool {
-	switch val := o.(type) {
-	case *obj.Boolean:
-		return o == obj.True
-	case obj.Integer:
-		return val.Val() != 0
-	case obj.Float:
-		return val.Val() != 0
-	case *obj.Null:
-		return false
-	default:
-		return true
-	}
-}
-
-func assertTypes(o obj.Object, types ...obj.Type) bool {
-	for _, t := range types {
-		if t == o.Type() {
-			return true
-		}
-	}
-	return false
-}
-
-func toFloat(l, r obj.Object) (obj.Object, obj.Object) {
-	if i, ok := l.(obj.Integer); ok {
-		l = obj.NewFloat(float64(i))
-	}
-	if i, ok := r.(obj.Integer); ok {
-		r = obj.NewFloat(float64(i))
-	}
-	return l, r
-}

--- a/internal/ast/notequals.go
+++ b/internal/ast/notequals.go
@@ -30,31 +30,31 @@ func (n NotEquals) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
 		return obj.NewError("unsupported operator '!=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType, obj.StringType, obj.BoolType, obj.NullType) {
 		return obj.NewError("unsupported operator '!=' for type %v", right.Type())
 	}
 
 	switch {
-	case assertTypes(right, obj.BoolType, obj.NullType) || assertTypes(right, obj.BoolType, obj.NullType):
+	case obj.AssertTypes(right, obj.BoolType, obj.NullType) || obj.AssertTypes(right, obj.BoolType, obj.NullType):
 		return obj.ParseBool(left != right)
 
-	case assertTypes(left, obj.StringType) && assertTypes(right, obj.StringType):
-		l := left.(obj.String).Val()
-		r := right.(obj.String).Val()
+	case obj.AssertTypes(left, obj.StringType) && obj.AssertTypes(right, obj.StringType):
+		l := left.(obj.String)
+		r := right.(obj.String)
 		return obj.ParseBool(l != r)
 
-	case assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType):
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
 		return obj.ParseBool(l != r)
 
-	case assertTypes(left, obj.FloatType, obj.IntType) && assertTypes(right, obj.FloatType, obj.IntType):
-		left, right = toFloat(left, right)
-		l := left.(obj.Float).Val()
-		r := right.(obj.Float).Val()
+	case obj.AssertTypes(left, obj.FloatType, obj.IntType) && obj.AssertTypes(right, obj.FloatType, obj.IntType):
+		left, right = obj.ToFloat(left, right)
+		l := left.(obj.Float)
+		r := right.(obj.Float)
 		return obj.ParseBool(l != r)
 
 	default:

--- a/internal/ast/or.go
+++ b/internal/ast/or.go
@@ -30,7 +30,7 @@ func (o Or) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	return obj.ParseBool(isTruthy(left) || isTruthy(right))
+	return obj.ParseBool(obj.IsTruthy(left) || obj.IsTruthy(right))
 }
 
 func (o Or) String() string {

--- a/internal/ast/plus.go
+++ b/internal/ast/plus.go
@@ -30,29 +30,29 @@ func (p Plus) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType, obj.StringType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType, obj.StringType) {
 		return obj.NewError("unsupported operator '+' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType, obj.StringType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType, obj.StringType) {
 		return obj.NewError("unsupported operator '+' for type %v", right.Type())
 	}
 
 	switch {
-	case assertTypes(left, obj.StringType) && assertTypes(right, obj.StringType):
-		l := left.(obj.String).Val()
-		r := right.(obj.String).Val()
-		return obj.NewString(l + r)
+	case obj.AssertTypes(left, obj.StringType) && obj.AssertTypes(right, obj.StringType):
+		l := left.(obj.String)
+		r := right.(obj.String)
+		return obj.String(l + r)
 
-	case assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType):
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return obj.NewInteger(l + r)
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
+		return obj.Integer(l + r)
 
-	case assertTypes(left, obj.FloatType, obj.IntType) && assertTypes(right, obj.FloatType, obj.IntType):
-		left, right = toFloat(left, right)
-		l := left.(obj.Float).Val()
-		r := right.(obj.Float).Val()
-		return obj.NewFloat(l + r)
+	case obj.AssertTypes(left, obj.FloatType, obj.IntType) && obj.AssertTypes(right, obj.FloatType, obj.IntType):
+		left, right = obj.ToFloat(left, right)
+		l := left.(obj.Float)
+		r := right.(obj.Float)
+		return obj.Float(l + r)
 
 	default:
 		return obj.NewError(

--- a/internal/ast/plusassign.go
+++ b/internal/ast/plusassign.go
@@ -34,48 +34,48 @@ func (p PlusAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType, obj.StringType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType, obj.StringType) {
 		return obj.NewError("unsupported operator '+=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType, obj.StringType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType, obj.StringType) {
 		return obj.NewError("unsupported operator '+=' for type %v", right.Type())
 	}
 
 	switch {
-	case assertTypes(left, obj.StringType) && assertTypes(right, obj.StringType):
+	case obj.AssertTypes(left, obj.StringType) && obj.AssertTypes(right, obj.StringType):
 		if gs, ok := left.(obj.GetSetter); ok {
-			l := gs.Object().(obj.String).Val()
-			r := right.(obj.String).Val()
-			return gs.Set(obj.NewString(l + r))
+			l := gs.Object().(obj.String)
+			r := right.(obj.String)
+			return gs.Set(obj.String(l + r))
 		}
 
-		l := left.(obj.String).Val()
-		r := right.(obj.String).Val()
-		return env.Set(name, obj.NewString(l+r))
+		l := left.(obj.String)
+		r := right.(obj.String)
+		return env.Set(name, obj.String(l+r))
 
-	case assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType):
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
 		if gs, ok := left.(obj.GetSetter); ok {
-			l := gs.Object().(obj.Integer).Val()
-			r := right.(obj.Integer).Val()
-			return gs.Set(obj.NewInteger(l + r))
+			l := gs.Object().(obj.Integer)
+			r := right.(obj.Integer)
+			return gs.Set(obj.Integer(l + r))
 		}
 
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return env.Set(name, obj.NewInteger(l+r))
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
+		return env.Set(name, obj.Integer(l+r))
 
-	case assertTypes(left, obj.FloatType, obj.IntType) && assertTypes(right, obj.FloatType, obj.IntType):
+	case obj.AssertTypes(left, obj.FloatType, obj.IntType) && obj.AssertTypes(right, obj.FloatType, obj.IntType):
 		if gs, ok := left.(obj.GetSetter); ok {
-			leftFl, rightFl := toFloat(gs.Object(), right)
-			l := leftFl.(obj.Float).Val()
-			r := rightFl.(obj.Float).Val()
-			return gs.Set(obj.NewFloat(l + r))
+			leftFl, rightFl := obj.ToFloat(gs.Object(), right)
+			l := leftFl.(obj.Float)
+			r := rightFl.(obj.Float)
+			return gs.Set(obj.Float(l + r))
 		}
 
-		leftFl, rightFl := toFloat(left, right)
-		l := leftFl.(obj.Float).Val()
-		r := rightFl.(obj.Float).Val()
-		return env.Set(name, obj.NewFloat(l+r))
+		leftFl, rightFl := obj.ToFloat(left, right)
+		l := leftFl.(obj.Float)
+		r := rightFl.(obj.Float)
+		return env.Set(name, obj.Float(l+r))
 
 	default:
 		return obj.NewError(

--- a/internal/ast/plusplus.go
+++ b/internal/ast/plusplus.go
@@ -29,29 +29,29 @@ func (p PlusPlus) Eval(env *obj.Env) obj.Object {
 		name = ident.String()
 	}
 
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '++' for type %v", right.Type())
 	}
 
-	if assertTypes(right, obj.IntType) {
+	if obj.AssertTypes(right, obj.IntType) {
 		if gs, ok := right.(obj.GetSetter); ok {
-			r := gs.Object().(obj.Integer).Val()
-			return gs.Set(obj.NewInteger(r + 1))
+			r := gs.Object().(obj.Integer)
+			return gs.Set(obj.Integer(r + 1))
 		}
 
-		r := right.(obj.Integer).Val()
-		return env.Set(name, obj.NewInteger(r+1))
+		r := right.(obj.Integer)
+		return env.Set(name, obj.Integer(r+1))
 	}
 
 	if gs, ok := right.(obj.GetSetter); ok {
-		rightFl, _ := toFloat(gs.Object(), obj.NullObj)
-		r := rightFl.(obj.Float).Val()
-		return gs.Set(obj.NewFloat(r + 1))
+		rightFl, _ := obj.ToFloat(gs.Object(), obj.NullObj)
+		r := rightFl.(obj.Float)
+		return gs.Set(obj.Float(r + 1))
 	}
 
-	rightFl, _ := toFloat(right, obj.NullObj)
-	r := rightFl.(obj.Float).Val()
-	return env.Set(name, obj.NewFloat(r+1))
+	rightFl, _ := obj.ToFloat(right, obj.NullObj)
+	r := rightFl.(obj.Float)
+	return env.Set(name, obj.Float(r+1))
 }
 
 func (p PlusPlus) String() string {

--- a/internal/ast/prefixmin.go
+++ b/internal/ast/prefixmin.go
@@ -25,10 +25,10 @@ func (p PrefixMinus) Eval(env *obj.Env) obj.Object {
 
 	switch v := value.(type) {
 	case obj.Integer:
-		return obj.NewInteger(-v.Val())
+		return obj.Integer(-v.Val())
 
 	case obj.Float:
-		return obj.NewFloat(-v.Val())
+		return obj.Float(-v.Val())
 
 	default:
 		return obj.NewError("unsupported prefix operator '-' for type %v", value.Type())

--- a/internal/ast/rawstring.go
+++ b/internal/ast/rawstring.go
@@ -15,7 +15,7 @@ func NewRawString(s string) Node {
 }
 
 func (r RawString) Eval(env *obj.Env) obj.Object {
-	return obj.NewString(string(r))
+	return obj.String(string(r))
 }
 
 func (r RawString) String() string {
@@ -32,7 +32,7 @@ func (r RawString) Quoted() string {
 }
 
 func (r RawString) Compile(c *compiler.Compiler) (position int, err error) {
-	return c.Emit(code.OpConstant, c.AddConstant(obj.NewString(string(r)))), nil
+	return c.Emit(code.OpConstant, c.AddConstant(obj.String(string(r)))), nil
 }
 
 func (r RawString) IsConstExpression() bool {

--- a/internal/ast/string.go
+++ b/internal/ast/string.go
@@ -33,7 +33,7 @@ func NewString(s string, parse parseFn) (Node, error) {
 
 func (s String) Eval(env *obj.Env) obj.Object {
 	if len(s.substr) == 0 {
-		return obj.NewString(s.s)
+		return obj.String(s.s)
 	}
 
 	var subs = make([]any, len(s.substr))
@@ -41,7 +41,7 @@ func (s String) Eval(env *obj.Env) obj.Object {
 		subs[i] = sub.Eval(env)
 	}
 
-	return obj.NewString(fmt.Sprintf(s.s, subs...))
+	return obj.String(fmt.Sprintf(s.s, subs...))
 }
 
 func (s String) String() string {
@@ -54,7 +54,7 @@ func (s String) Quoted() string {
 
 func (s String) Compile(c *compiler.Compiler) (position int, err error) {
 	if len(s.substr) == 0 {
-		return c.Emit(code.OpConstant, c.AddConstant(obj.NewString(s.s))), nil
+		return c.Emit(code.OpConstant, c.AddConstant(obj.String(s.s))), nil
 	}
 
 	for _, sub := range s.substr {
@@ -64,7 +64,7 @@ func (s String) Compile(c *compiler.Compiler) (position int, err error) {
 		c.RemoveLast()
 	}
 
-	return c.Emit(code.OpInterpolate, c.AddConstant(obj.NewString(s.s)), len(s.substr)), nil
+	return c.Emit(code.OpInterpolate, c.AddConstant(obj.String(s.s)), len(s.substr)), nil
 }
 
 func (s String) IsConstExpression() bool {

--- a/internal/ast/string.go
+++ b/internal/ast/string.go
@@ -141,14 +141,14 @@ const eof = -1
 var errBadInterpolationSyntax = errors.New("bad interpolation syntax")
 
 type interpolator struct {
-	s          string
+	parse parseFn
+	s     string
+	strings.Builder
 	pos        int
 	width      int
 	nblocks    int
 	inQuotes   bool
 	inBacktick bool
-	parse      parseFn
-	strings.Builder
 }
 
 func newInterpolator(s string, parse parseFn) interpolator {

--- a/internal/ast/times.go
+++ b/internal/ast/times.go
@@ -30,23 +30,23 @@ func (t Times) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '*' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '*' for type %v", right.Type())
 	}
 
-	if assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType) {
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return obj.NewInteger(l * r)
+	if obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType) {
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
+		return obj.Integer(l * r)
 	}
 
-	left, right = toFloat(left, right)
-	l := left.(obj.Float).Val()
-	r := right.(obj.Float).Val()
-	return obj.NewFloat(l * r)
+	left, right = obj.ToFloat(left, right)
+	l := left.(obj.Float)
+	r := right.(obj.Float)
+	return obj.Float(l * r)
 }
 
 func (t Times) String() string {

--- a/internal/ast/timesassign.go
+++ b/internal/ast/timesassign.go
@@ -34,37 +34,37 @@ func (t TimesAssign) Eval(env *obj.Env) obj.Object {
 		return right
 	}
 
-	if !assertTypes(left, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(left, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '*=' for type %v", left.Type())
 	}
-	if !assertTypes(right, obj.IntType, obj.FloatType) {
+	if !obj.AssertTypes(right, obj.IntType, obj.FloatType) {
 		return obj.NewError("unsupported operator '*=' for type %v", right.Type())
 	}
 
 	switch {
-	case assertTypes(left, obj.IntType) && assertTypes(right, obj.IntType):
+	case obj.AssertTypes(left, obj.IntType) && obj.AssertTypes(right, obj.IntType):
 		if gs, ok := left.(obj.GetSetter); ok {
-			l := gs.Object().(obj.Integer).Val()
-			r := right.(obj.Integer).Val()
-			return gs.Set(obj.NewInteger(l * r))
+			l := gs.Object().(obj.Integer)
+			r := right.(obj.Integer)
+			return gs.Set(obj.Integer(l * r))
 		}
 
-		l := left.(obj.Integer).Val()
-		r := right.(obj.Integer).Val()
-		return env.Set(name, obj.NewInteger(l*r))
+		l := left.(obj.Integer)
+		r := right.(obj.Integer)
+		return env.Set(name, obj.Integer(l*r))
 
-	case assertTypes(left, obj.FloatType, obj.IntType) && assertTypes(right, obj.FloatType, obj.IntType):
+	case obj.AssertTypes(left, obj.FloatType, obj.IntType) && obj.AssertTypes(right, obj.FloatType, obj.IntType):
 		if gs, ok := left.(obj.GetSetter); ok {
-			leftFl, rightFl := toFloat(gs.Object(), right)
-			l := leftFl.(obj.Float).Val()
-			r := rightFl.(obj.Float).Val()
-			return gs.Set(obj.NewFloat(l * r))
+			leftFl, rightFl := obj.ToFloat(gs.Object(), right)
+			l := leftFl.(obj.Float)
+			r := rightFl.(obj.Float)
+			return gs.Set(obj.Float(l * r))
 		}
 
-		leftFl, rightFl := toFloat(left, right)
-		l := leftFl.(obj.Float).Val()
-		r := rightFl.(obj.Float).Val()
-		return env.Set(name, obj.NewFloat(l*r))
+		leftFl, rightFl := obj.ToFloat(left, right)
+		l := leftFl.(obj.Float)
+		r := rightFl.(obj.Float)
+		return env.Set(name, obj.Float(l*r))
 
 	default:
 		return obj.NewError(

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -24,10 +24,10 @@ type CompilationScope struct {
 }
 
 type Compiler struct {
-	constants  *[]obj.Object
+	constants *[]obj.Object
+	*SymbolTable
 	scopes     []CompilationScope
 	scopeIndex int
-	*SymbolTable
 }
 
 type Bytecode struct {

--- a/internal/compiler/symboltable.go
+++ b/internal/compiler/symboltable.go
@@ -19,8 +19,8 @@ type Symbol struct {
 type SymbolTable struct {
 	outer       *SymbolTable
 	Store       map[string]Symbol
-	NumDefs     int
 	FreeSymbols []Symbol
+	NumDefs     int
 }
 
 func NewSymbolTable() *SymbolTable {

--- a/internal/item/item.go
+++ b/internal/item/item.go
@@ -3,8 +3,8 @@ package item
 import "fmt"
 
 type Item struct {
-	Typ Type
 	Val string
+	Typ Type
 	Pos int
 }
 

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -10,11 +10,11 @@ import (
 )
 
 type lexer struct {
+	items chan item.Item
 	input string
 	start int
 	pos   int
 	width int
-	items chan item.Item
 }
 
 type stateFn func(*lexer) stateFn

--- a/internal/obj/builtin.go
+++ b/internal/obj/builtin.go
@@ -40,14 +40,14 @@ func ResolveBuiltin(name string) (Builtin, bool) {
 }
 
 type BuiltinImpl struct {
-	Name    string
 	Builtin Builtin
+	Name    string
 }
 
 var Builtins = []BuiltinImpl{
 	{
-		"len",
-		func(args ...Object) Object {
+		Name: "len",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 1 {
 				return NewError("len: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -65,22 +65,22 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"println",
-		func(args ...Object) Object {
+		Name: "println",
+		Builtin: func(args ...Object) Object {
 			fmt.Fprintln(Stdout, toAnySlice(args)...)
 			return NullObj
 		},
 	},
 	{
-		"print",
-		func(args ...Object) Object {
+		Name: "print",
+		Builtin: func(args ...Object) Object {
 			fmt.Fprint(Stdout, toAnySlice(args)...)
 			return NullObj
 		},
 	},
 	{
-		"input",
-		func(args ...Object) Object {
+		Name: "input",
+		Builtin: func(args ...Object) Object {
 			var tmp string
 
 			args = UnwrapAll(args)
@@ -99,8 +99,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"string",
-		func(args ...Object) Object {
+		Name: "string",
+		Builtin: func(args ...Object) Object {
 			if len(args) == 0 {
 				return NewError("string: no argument provided")
 			}
@@ -113,14 +113,14 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"error",
-		func(args ...Object) Object {
+		Name: "error",
+		Builtin: func(args ...Object) Object {
 			return NewError(fmt.Sprint(toAnySlice(args)...))
 		},
 	},
 	{
-		"type",
-		func(args ...Object) Object {
+		Name: "type",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 1 {
 				return NewError("type: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -128,8 +128,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"int",
-		func(args ...Object) Object {
+		Name: "int",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 1 {
 				return NewError("int: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -154,8 +154,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"float",
-		func(args ...Object) Object {
+		Name: "float",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 1 {
 				return NewError("float: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -180,8 +180,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"exit",
-		func(args ...Object) Object {
+		Name: "exit",
+		Builtin: func(args ...Object) Object {
 			args = UnwrapAll(args)
 
 			switch l := len(args); l {
@@ -221,8 +221,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"append",
-		func(args ...Object) Object {
+		Name: "append",
+		Builtin: func(args ...Object) Object {
 			if len(args) == 0 {
 				return NewError("append: no argument provided")
 			}
@@ -240,8 +240,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"push",
-		func(args ...Object) Object {
+		Name: "push",
+		Builtin: func(args ...Object) Object {
 			if len(args) == 0 {
 				return NewError("push: no argument provided")
 			}
@@ -265,8 +265,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"range",
-		func(args ...Object) Object {
+		Name: "range",
+		Builtin: func(args ...Object) Object {
 			args = UnwrapAll(args)
 
 			switch len(args) {
@@ -315,8 +315,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"new",
-		func(args ...Object) Object {
+		Name: "new",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 0 {
 				return NewError("new: wrong number of arguments, expected 0, got %d", l)
 			}
@@ -324,8 +324,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"failed",
-		func(args ...Object) Object {
+		Name: "failed",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 1 {
 				return NewError("failed: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -335,8 +335,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"plugin",
-		func(args ...Object) Object {
+		Name: "plugin",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 1 {
 				return NewError("plugin: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -350,8 +350,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"pipe",
-		func(args ...Object) Object {
+		Name: "pipe",
+		Builtin: func(args ...Object) Object {
 			switch l := len(args); l {
 			case 0:
 				return NewPipe()
@@ -369,8 +369,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"send",
-		func(args ...Object) (o Object) {
+		Name: "send",
+		Builtin: func(args ...Object) (o Object) {
 			if l := len(args); l != 2 {
 				return NewError("send: wrong number of arguments, expected 2, got %d", l)
 			}
@@ -386,8 +386,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"recv",
-		func(args ...Object) (o Object) {
+		Name: "recv",
+		Builtin: func(args ...Object) (o Object) {
 			if l := len(args); l != 1 {
 				return NewError("recv: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -404,8 +404,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"close",
-		func(args ...Object) (o Object) {
+		Name: "close",
+		Builtin: func(args ...Object) (o Object) {
 			if l := len(args); l != 1 {
 				return NewError("close: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -420,8 +420,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"hex",
-		func(args ...Object) Object {
+		Name: "hex",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 1 {
 				return NewError("hex: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -435,8 +435,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"oct",
-		func(args ...Object) Object {
+		Name: "oct",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 1 {
 				return NewError("oct: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -450,8 +450,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"bin",
-		func(args ...Object) Object {
+		Name: "bin",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 1 {
 				return NewError("bin: wrong number of arguments, expected 1, got %d", l)
 			}
@@ -465,8 +465,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"slice",
-		func(args ...Object) Object {
+		Name: "slice",
+		Builtin: func(args ...Object) Object {
 			if l := len(args); l != 3 {
 				return NewError("slice: wrong number of arguments, expected 3, got %d", l)
 			}
@@ -515,8 +515,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"open",
-		func(args ...Object) Object {
+		Name: "open",
+		Builtin: func(args ...Object) Object {
 			var l = len(args)
 
 			if l != 1 && l != 2 {
@@ -550,8 +550,8 @@ var Builtins = []BuiltinImpl{
 		},
 	},
 	{
-		"bytes",
-		func(args ...Object) Object {
+		Name: "bytes",
+		Builtin: func(args ...Object) Object {
 			if len(args) != 1 {
 				return NewError("bytes: expected 1 argument but got %d", len(args))
 			}

--- a/internal/obj/function.go
+++ b/internal/obj/function.go
@@ -12,9 +12,9 @@ type Evaluable interface {
 }
 
 type Function struct {
-	Params       []string
-	Body         Evaluable
-	Env          *Env
+	Body   Evaluable
+	Env    *Env
+	Params []string
 }
 
 func NewFunction(params []string, env *Env, body Evaluable) Object {
@@ -31,8 +31,8 @@ func (f Function) String() string {
 
 type CompiledFunction struct {
 	Instructions code.Instructions
-	NumLocals int
-	NumParams int
+	NumLocals    int
+	NumParams    int
 }
 
 func NewFunctionCompiled(i code.Instructions, nLocals, nParams int) Object {

--- a/internal/obj/object.go
+++ b/internal/obj/object.go
@@ -89,6 +89,44 @@ func Unwrap(o Object) Object {
 	return o
 }
 
+func AssertTypes(o Object, types ...Type) bool {
+	for _, t := range types {
+		if t == o.Type() {
+			return true
+		}
+	}
+	return false
+}
+
+func IsPrimitive(o Object) bool {
+	return AssertTypes(o, BoolType, ErrorType, FloatType, IntType, StringType)
+}
+
+func ToFloat(l, r Object) (Object, Object) {
+	if i, ok := l.(Integer); ok {
+		l = Float(i)
+	}
+	if i, ok := r.(Integer); ok {
+		r = Float(i)
+	}
+	return l, r
+}
+
+func IsTruthy(o Object) bool {
+	switch val := o.(type) {
+	case *Boolean:
+		return o == True
+	case Integer:
+		return val != 0
+	case Float:
+		return val != 0
+	case *Null:
+		return false
+	default:
+		return true
+	}
+}
+
 var (
 	ErrFileNotFound   = errors.New("file not found")
 	ErrNoFileProvided = errors.New("no file provided")

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -10,13 +10,13 @@ import (
 )
 
 type Parser struct {
-	cur           item.Item
-	peek          item.Item
 	items         chan item.Item
-	errs          []string
-	nestedLoops   uint
 	prefixParsers map[item.Type]parsePrefixFn
 	infixParsers  map[item.Type]parseInfixFn
+	cur           item.Item
+	peek          item.Item
+	errs          []string
+	nestedLoops   uint
 }
 
 type (

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -17,9 +17,9 @@ import (
 )
 
 type State struct {
+	Symbols *compiler.SymbolTable
 	Consts  []obj.Object
 	Globals []obj.Object
-	Symbols *compiler.SymbolTable
 }
 
 func NewState() *State {
@@ -36,15 +36,14 @@ func NewState() *State {
 }
 
 type VM struct {
-	stack      []obj.Object
-	sp         int
-	frames     []*Frame
-	frameIndex int
+	*State
 	dir        string
 	file       string
-	// Keeps track of the locally defined globals.
+	stack      []obj.Object
+	frames     []*Frame
 	localTable []bool
-	*State
+	sp         int
+	frameIndex int
 }
 
 const (

--- a/profile.go
+++ b/profile.go
@@ -1,0 +1,61 @@
+//go:build ignore
+
+package main
+
+import (
+	"os"
+	"runtime/pprof"
+
+	"github.com/NicoNex/tau/internal/compiler"
+	"github.com/NicoNex/tau/internal/parser"
+	"github.com/NicoNex/tau/internal/vm"
+)
+
+const fib = `
+fib = fn(n) {
+	if n < 2 {
+		return n
+	}
+	fib(n-1) + fib(n-2)
+}
+
+fib(35)`
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func code(path string) string {
+	b, err := os.ReadFile(path)
+	check(err)
+
+	return string(b)
+}
+
+func fileOrDefault() string {
+	if len(os.Args) > 1 {
+		return code(os.Args[1])
+	}
+	return fib
+}
+
+func main() {
+	cpuf, err := os.Create("cpu.prof")
+	check(err)
+
+	tree, errs := parser.Parse(fileOrDefault())
+	if len(errs) > 0 {
+		panic("parser errors")
+	}
+
+	c := compiler.New()
+	check(c.Compile(tree))
+
+	check(pprof.StartCPUProfile(cpuf))
+	defer pprof.StopCPUProfile()
+
+	tvm := vm.New("<profiler>", c.Bytecode())
+	check(tvm.Run())
+}

--- a/repl.go
+++ b/repl.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 package tau
 
 import (
@@ -50,7 +47,7 @@ func EvalREPL() error {
 			continue
 		}
 
-		if val := res.Eval(env); val != nil && val != obj.NullObj {
+		if val := res.Eval(env); val != nil && obj.IsPrimitive(val) {
 			fmt.Fprintln(t, val)
 		}
 	}
@@ -101,7 +98,7 @@ func VmREPL() error {
 			continue
 		}
 
-		if val := tvm.LastPoppedStackElem(); val != nil && val != obj.NullObj {
+		if val := tvm.LastPoppedStackElem(); val != nil && obj.IsPrimitive(val) {
 			fmt.Fprintln(t, val)
 		}
 	}

--- a/simplerepl.go
+++ b/simplerepl.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package tau
 
 import (
@@ -15,7 +12,7 @@ import (
 	"github.com/NicoNex/tau/internal/vm"
 )
 
-func EvalREPL() {
+func SimpleEvalREPL() {
 	var (
 		env    = obj.NewEnv("<stdin>")
 		reader = bufio.NewReader(os.Stdin)
@@ -25,12 +22,12 @@ func EvalREPL() {
 	for {
 		fmt.Print(">>> ")
 		input, err := reader.ReadString('\n')
-		check(err)
+		simpleCheck(err)
 
 		input = strings.TrimRight(input, " \n")
 		if len(input) > 0 && input[len(input)-1] == '{' {
-			input, err = acceptUntil(reader, input, "\n\n")
-			check(err)
+			input, err = simpleAcceptUntil(reader, input, "\n\n")
+			simpleCheck(err)
 		}
 
 		res, errs := parser.Parse(input)
@@ -41,13 +38,13 @@ func EvalREPL() {
 			continue
 		}
 
-		if val := res.Eval(env); val != nil && val != obj.NullObj {
+		if val := res.Eval(env); val != nil && obj.IsPrimitive(val) {
 			fmt.Println(val)
 		}
 	}
 }
 
-func VmREPL() {
+func SimpleVmREPL() {
 	var (
 		state  = vm.NewState()
 		reader = bufio.NewReader(os.Stdin)
@@ -57,12 +54,12 @@ func VmREPL() {
 	for {
 		fmt.Print(">>> ")
 		input, err := reader.ReadString('\n')
-		check(err)
+		simpleCheck(err)
 
 		input = strings.TrimRight(input, " \n")
 		if len(input) > 0 && input[len(input)-1] == '{' {
-			input, err = acceptUntil(reader, input, "\n\n")
-			check(err)
+			input, err = simpleAcceptUntil(reader, input, "\n\n")
+			simpleCheck(err)
 		}
 
 		res, errs := parser.Parse(input)
@@ -85,18 +82,20 @@ func VmREPL() {
 			continue
 		}
 
-		fmt.Println(tvm.LastPoppedStackElem())
+		if val := tvm.LastPoppedStackElem(); val != nil && obj.IsPrimitive(val) {
+			fmt.Println(val)
+		}
 	}
 }
 
-func check(err error) {
+func simpleCheck(err error) {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(0)
 	}
 }
 
-func acceptUntil(r *bufio.Reader, start, end string) (string, error) {
+func simpleAcceptUntil(r *bufio.Reader, start, end string) (string, error) {
 	var buf strings.Builder
 
 	buf.WriteString(start)

--- a/stdlib/lists.tau
+++ b/stdlib/lists.tau
@@ -1,0 +1,17 @@
+Contains = fn(list, item) {
+	for i = 0; i < len(list); ++i {
+		if list[i] == item {
+			return true
+		}
+	}
+	return false
+}
+
+Index = fn(list, item) {
+	for i = 0; i < len(list); ++i {
+		if list[i] == item {
+			return i
+		}
+	}
+	return -1
+}

--- a/stdlib/strings.tau
+++ b/stdlib/strings.tau
@@ -150,31 +150,45 @@ Reverse = fn(str) {
 	return ret
 }
 
-split = fn(str, sep, n, after) {
-	ret = []
-
-	if n == 0 {
-		return ret
+split = fn(str, sep, n) {
+	if sep == "" {
+		return error("split: empty separator")
 	}
 
-	x = if after { 1 } else { 0 }
-
+	ret = []
 	for (idx = Index(str, sep)) != -1 && n != 0 {
-		ret = append(ret, slice(str, 0, idx + x))
-		str = slice(str, idx + 1, len(str))
+		if idx > 0 {
+			ret = append(ret, slice(str, 0, idx))
+		}
+		str = slice(str, idx + len(sep), len(str))
 		--n
 	}
 
 	return append(ret, str)
 }
 
-SplitAfterN = fn(str, sep, n) {	split(str, sep, n, true) }
+splitAfter = fn(str, sep, n) {
+	if sep == "" {
+		return error("splitAfter: empty separator")
+	}
 
-SplitAfter = fn(str, sep) { split(str, sep, -1, true) }
+	ret = []
+	for (idx = Index(str, sep)) != -1 && n != 0 {
+		ret = append(ret, slice(str, 0, idx + len(sep)))
+		str = slice(str, idx + len(sep), len(str))
+		--n
+	}
 
-SplitN = fn(str, sep, n) { split(str, sep, n, false) }
+	return append(ret, str)
+}
 
-Split = fn(str, sep) { split(str, sep, -1, false) }
+SplitAfterN = fn(str, sep, n) {	splitAfter(str, sep, n) }
+
+SplitAfter = fn(str, sep) { splitAfter(str, sep, -1) }
+
+SplitN = fn(str, sep, n) { split(str, sep, n) }
+
+Split = fn(str, sep) { split(str, sep, -1) }
 
 Fields = fn(str) {
 	ret = []

--- a/stdlib/strings.tau
+++ b/stdlib/strings.tau
@@ -1,0 +1,169 @@
+Clone = fn(str) {
+	ret = ""
+
+	for i = 0; i < len(str); ++i {
+		ret += str[i]
+	}
+
+	return ret
+}
+
+Contains = fn(str, sub) {
+	maxAttempts = len(str) - len(sub)
+	for i = 0; i <= maxAttempts; ++i {
+		if sub == slice(str, i, i + len(sub)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+ContainsAny = fn(str, chars) {
+	for i = 0; i < len(chars); ++i {
+		if Contains(str, chars[i]) {
+			return true
+		}
+	}
+
+	return false
+}
+
+Count = fn(str, sub) {
+	total = 0
+
+	maxAttempts = len(str) - len(sub)
+	for i = 0; i < maxAttempts; ++i {
+		if sub == slice(str, i, i + len(sub)) {
+			++total
+		}
+	}
+
+	return total
+}
+
+cutResult = fn(before, after, found) {
+	res = new()
+	res.Before = before
+	res.After = after
+	res.Found = found
+
+	return res
+}
+
+Cut = fn(str, sub) {
+	maxAttempts = len(str) - len(sub)
+	for i = 0; i < maxAttempts; ++i {
+		if sub == slice(str, i, i + len(sub)) {
+			return cutResult(
+				slice(str, 0, i),
+				slice(str, i + len(sub), len(str)),
+				true
+			)
+		}
+	}
+
+	return cutResult(str, "", false)
+}
+
+HasPrefix = fn(str, pre) {
+	if len(pre) > len(str) {
+		return false
+	}
+
+	return slice(str, 0, len(pre)) == pre
+}
+
+HasSuffix = fn(str, sub) {
+	if len(sub) > len(str) {
+		return false
+	}
+
+	return slice(str, len(str) - len(sub), len(str)) == sub
+}
+
+Index = fn(str, sub) {
+	maxAttempts = len(str) - len(sub)
+	for i = 0; i <= maxAttempts; ++i {
+		if sub == slice(str, i, i + len(sub)) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+IndexAny = fn(str, chars) {
+	index = -1
+	for i = 0; i < len(chars); ++i {
+		tmp = Index(str, chars[i])
+		if tmp != -1 && index > tmp || index == -1 {
+			index = tmp
+		}
+	}
+
+	return index
+}
+
+Join = fn(arr, sep) {
+	str = ""
+	for i = 0; i < len(arr); ++i {
+		if type(arr[i]) != "string" {
+			return error("array element at index {i} is not a string")
+		}
+
+		str += if i < len(arr) - 1 { arr[i] + sep } else { arr[i] }
+	}
+
+	return str
+}
+
+LastIndex = fn(str, sub) {
+	for i = len(str); i >= 0; --i {
+		if sub == slice(str, i - len(sub), i) {
+			return i - len(sub)
+		}
+	}
+
+	return -1
+}
+
+LastIndexAny = fn(str, chars) {
+	index = -1
+	for i = 0; i < len(chars); ++i {
+		tmp = LastIndex(str, chars[i])
+		if tmp != -1 && tmp > index || index == -1 {
+			index = tmp
+		}
+	}
+
+	return index
+}
+
+Repeat = fn(str, n) {
+	ret = ""
+	for i = 0; i < n; ++i {
+		ret += str
+	}
+
+	return ret
+}
+
+Reverse = fn(str) {
+	ret = ""
+	for i = len(str) - 1; i >= 0; --i {
+		ret += str[i]
+	}
+
+	return ret
+}
+
+Split = fn(str, sep) {
+	ret = []
+	for (i = Index(str, sep)) != -1 {
+		ret = append(ret, slice(str, 0, i))
+		str = slice(str, i + 1, len(str))
+	}
+
+	return append(ret, str)
+}

--- a/stdlib/strings.tau
+++ b/stdlib/strings.tau
@@ -159,36 +159,22 @@ split = fn(str, sep, n, after) {
 
 	x = if after { 1 } else { 0 }
 
-	if n < 0 {
-		for (idx = Index(str, sep)) != -1 {
-			ret = append(ret, slice(str, 0, idx + x))
-			str = slice(str, idx + 1, len(str))
-		}
-
-		return append(ret, str)
+	for (idx = Index(str, sep)) != -1 && n != 0 {
+		ret = append(ret, slice(str, 0, idx + x))
+		str = slice(str, idx + 1, len(str))
+		--n
 	}
 
-	if n > 0 {
-		for i = 1; i < n; ++i {
-			if (idx = Index(str, sep)) != -1 {
-				ret = append(ret, slice(str, 0, idx + x))
-				str = slice(str, idx + 1, len(str))
-			} else {
-				break
-			}
-		}
-
-		return append(ret, str)
-	}
+	return append(ret, str)
 }
 
-SplitAfterN = fn(str, sep, n) {	return split(str, sep, n, true) }
+SplitAfterN = fn(str, sep, n) {	split(str, sep, n, true) }
 
-SplitAfter = fn(str, sep) { return split(str, sep, -1, true) }
+SplitAfter = fn(str, sep) { split(str, sep, -1, true) }
 
-SplitN = fn(str, sep, n) { return split(str, sep, n, false) }
+SplitN = fn(str, sep, n) { split(str, sep, n, false) }
 
-Split = fn(str, sep) { return split(str, sep, -1, false) }
+Split = fn(str, sep) { split(str, sep, -1, false) }
 
 Fields = fn(str) {
 	ret = []

--- a/stdlib/strings.tau
+++ b/stdlib/strings.tau
@@ -150,15 +150,45 @@ Reverse = fn(str) {
 	return ret
 }
 
-Split = fn(str, sep) {
+split = fn(str, sep, n, after) {
 	ret = []
-	for (i = Index(str, sep)) != -1 {
-		ret = append(ret, slice(str, 0, i))
-		str = slice(str, i + 1, len(str))
+
+	if n == 0 {
+		return ret
 	}
 
-	return append(ret, str)
+	x = if after { 1 } else { 0 }
+
+	if n < 0 {
+		for (idx = Index(str, sep)) != -1 {
+			ret = append(ret, slice(str, 0, idx + x))
+			str = slice(str, idx + 1, len(str))
+		}
+
+		return append(ret, str)
+	}
+
+	if n > 0 {
+		for i = 1; i < n; ++i {
+			if (idx = Index(str, sep)) != -1 {
+				ret = append(ret, slice(str, 0, idx + x))
+				str = slice(str, idx + 1, len(str))
+			} else {
+				break
+			}
+		}
+
+		return append(ret, str)
+	}
 }
+
+SplitAfterN = fn(str, sep, n) {	return split(str, sep, n, true) }
+
+SplitAfter = fn(str, sep) { return split(str, sep, -1, true) }
+
+SplitN = fn(str, sep, n) { return split(str, sep, n, false) }
+
+Split = fn(str, sep) { return split(str, sep, -1, false) }
 
 Fields = fn(str) {
 	ret = []

--- a/stdlib/strings.tau
+++ b/stdlib/strings.tau
@@ -157,3 +157,87 @@ Split = fn(str, sep) {
 
 	return append(ret, str)
 }
+
+TrimPrefix = fn(str, pre) {
+	return if len(pre) > len(str) || pre != slice(str, 0, len(pre)) {
+		str
+	} else {
+		slice(str, len(pre), len(str))
+	}
+}
+
+TrimSuffix = fn(str, sub) {
+	return if len(sub) > len(str) || sub != slice(str, len(str)-len(sub), len(str)) {
+		str
+	} else {
+		slice(str, 0, len(str)-len(sub))
+	}
+}
+
+ReplaceAll = fn(str, old, new) { Join(Split(str, old), new) }
+
+Replace = fn(str, old, new, n) {
+	if n < 0 {
+		return ReplaceAll(str, old, new)
+	}
+
+	ret = ""
+	for i = 0; i < n; ++i {
+		if (idx = Index(str, old)) == -1 {
+			break
+		}
+		ret += slice(str, 0, idx) + new
+		str = slice(str, idx+len(old), len(str))
+	}
+
+	return ret + str
+}
+
+isalpha = fn(char) { char >= 97 && char <= 122 || char >= 65 && char <= 90 }
+islower = fn(char) { char >= 97 && char <= 122 }
+isupper = fn(char) { char >= 65 && char <= 90 }
+toupper = fn(char) { char - 32 }
+tolower = fn(char) { char + 32 }
+
+ToUpper = fn(str) {
+	b = bytes(str)
+	ret = []
+
+	for i = 0; i < len(b); ++i {
+		char = b[i]
+		ret = append(ret, if islower(char) { toupper(char) } else { char })
+	}
+
+	return string(bytes(ret))
+}
+
+ToLower = fn(str) {
+	b = bytes(str)
+	ret = []
+
+	for i = 0; i < len(b); ++i {
+		char = b[i]
+		ret = append(ret, if isupper(char) { tolower(char) } else { char })
+	}
+
+	return string(bytes(ret))
+}
+
+ToTitle = fn(str) {
+	toks = Split(str, " ")
+	ret = []
+
+	for i = 0; i < len(toks); ++i {
+		b = bytes(toks[i])
+		tmp = []
+
+		tmp = append(tmp, if islower(b[0]) { toupper(b[0]) } else { b[0] })
+		for j = 1; j < len(b); ++j {
+			tmp = append(tmp, b[j])
+		}
+
+		ret = append(ret, string(bytes(tmp)))
+	}
+
+	return Join(ret, " ")
+}

--- a/stdlib/strings.tau
+++ b/stdlib/strings.tau
@@ -1,13 +1,3 @@
-Clone = fn(str) {
-	ret = ""
-
-	for i = 0; i < len(str); ++i {
-		ret += str[i]
-	}
-
-	return ret
-}
-
 Contains = fn(str, sub) {
 	maxAttempts = len(str) - len(sub)
 	for i = 0; i <= maxAttempts; ++i {

--- a/stdlib/strings.tau
+++ b/stdlib/strings.tau
@@ -1,3 +1,5 @@
+spaces = "\t\n\v\f\r "
+
 Contains = fn(str, sub) {
 	maxAttempts = len(str) - len(sub)
 	for i = 0; i <= maxAttempts; ++i {
@@ -158,6 +160,16 @@ Split = fn(str, sep) {
 	return append(ret, str)
 }
 
+Fields = fn(str) {
+	ret = []
+	for (i = IndexAny(str, spaces)) != -1 {
+		ret = append(ret, slice(str, 0, i))
+		str = slice(str, i + 1, len(str))
+	}
+
+	return append(ret, str)
+}
+
 TrimPrefix = fn(str, pre) {
 	return if len(pre) > len(str) || pre != slice(str, 0, len(pre)) {
 		str
@@ -241,3 +253,27 @@ ToTitle = fn(str) {
 
 	return Join(ret, " ")
 }
+
+TrimLeft = fn(str, cutset) {
+	for start = 0; start < len(str); ++start {
+		if !Contains(cutset, str[start]) {
+			break
+		}
+	}
+
+	return slice(str, start, len(str))
+}
+
+TrimRight = fn(str, cutset) {
+	for stop = len(str); stop > 0; --stop {
+		if !Contains(cutset, str[stop-1]) {
+			break
+		}
+	}
+
+	return slice(str, 0, stop)
+}
+
+Trim = fn(str, cutset) { TrimRight(TrimLeft(str, cutset), cutset) }
+
+TrimSpace = fn(str) { Trim(str, spaces) }

--- a/tau.go
+++ b/tau.go
@@ -19,7 +19,7 @@ import (
 	"github.com/NicoNex/tau/internal/vm"
 )
 
-const TauVersion = "v1.4.5"
+const TauVersion = "v1.4.6"
 
 var ErrParseError = errors.New("error: parse error")
 


### PR DESCRIPTION
Hey, I just implemented a few methods for the `stdlib/strings` library.

Here's a list of all the methods I'd like to implement in the final version:

- [x] ~Clone~
- [x] Contains
- [x] ContainsAny
- [x] Count
- [x] Cut
- [x] Fields
- [x] HasPrefix
- [x] HasSuffix
- [x] Index
- [x] IndexAny
- [x] Join
- [x] LastIndex
- [x] LastIndexAny
- [x] Repeat
- [x] Replace
- [x] ReplaceAll
- [x] Reverse
- [x] Split
- [x] SplitAfter
- [x] SplitAfterN
- [x] SplitN
- [x] ToLower
- [x] ToTitle
- [x] ToUpper
- [x] Trim
- [x] TrimLeft
- [x] TrimPrefix
- [x] TrimRight
- [x] TrimSpace
- [x] TrimSuffix

Of course, more methods can be suggested and added to the list.